### PR TITLE
CAF-2257: Removed integration-test profile, moved it's start and stop container executions…

### DIFF
--- a/worker-batch-archetype/pom.xml
+++ b/worker-batch-archetype/pom.xml
@@ -16,7 +16,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/worker-batch-archetype/src/main/resources/archetype-resources/__rootArtifactId__-batch-plugin/src/test/java/__workerName__BatchPluginTest.java
+++ b/worker-batch-archetype/src/main/resources/archetype-resources/__rootArtifactId__-batch-plugin/src/test/java/__workerName__BatchPluginTest.java
@@ -109,7 +109,8 @@ public class ${workerName}BatchPluginTest
         return testContents;
     }
 
-    private Map<String, String> createTaskMessageParams(Map.Entry<String, String>... entries)
+    @SafeVarargs
+    private final Map<String, String> createTaskMessageParams(Map.Entry<String, String>... entries)
     {
         Map<String, String> testTaskMessageParams = new HashMap<>();
         for(Map.Entry<String, String> entry: entries){

--- a/worker-batch-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
+++ b/worker-batch-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/pom.xml
@@ -124,35 +124,6 @@
                 <rabbitmq.ctrl.port>15672</rabbitmq.ctrl.port>
             </properties>
         </profile>
-
-        <profile>
-            <id>integration-test</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>${fabric8.docker.maven.version}</version>
-                        <executions>
-                            <execution>
-                                <id>start</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <build>
@@ -265,6 +236,20 @@
                         <phase>package</phase>
                         <goals>
                             <goal>build</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/worker-batch-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/worker-batch-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,6 +30,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <caf.worker-batch-framework.version>${project.version}</caf.worker-batch-framework.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencyManagement>

--- a/worker-batch-archetype/src/test/resources/projects/basic/goal.txt
+++ b/worker-batch-archetype/src/test/resources/projects/basic/goal.txt
@@ -1,1 +1,1 @@
-install -Pintegration-test
+install


### PR DESCRIPTION
… to the Docker maven plugin standard build life-cycle for generated archetype project. Added project encoding properties to the generated project's aggregator.