### PR TITLE
CAF-2670: Enable support for resetting the 'trackTo' field when job has no subtasks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-framework</artifactId>
-                <version>2.3.1-301</version>
+                <version>2.4.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
+++ b/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
@@ -20,6 +20,7 @@ import com.hpe.caf.api.Codec;
 import com.hpe.caf.api.worker.*;
 import com.hpe.caf.worker.AbstractWorker;
 import com.rabbitmq.client.Connection;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -94,17 +95,17 @@ public class BatchWorker extends AbstractWorker<BatchWorkerTask, BatchWorkerResu
                     //  Also reset the 'trackTo' field on the tracking information but only if there are no
                     //  subtasks.
                     if (batchWorkerServices.hasSubtasks()) {
-                        return createSuccessNoOutputToQueue(false);
+                        return createSuccessNoOutputToQueue(tracking == null ? StringUtils.EMPTY : tracking.getTrackTo());
                     } else {
-                        return createSuccessNoOutputToQueue(true);
+                        return createSuccessNoOutputToQueue(null);
                     }
                 case RETURN_ONLY_IF_ZERO_SUBTASKS:
                     // We only return a result to the output queue if there were zero subfiles with the batch
                     if(batchWorkerServices.hasSubtasks()) {
-                        // If there are subtasks, don't send to output queue
-                        return createSuccessNoOutputToQueue(false);
+                        // If there are sub tasks, don't send to output queue
+                        return createSuccessNoOutputToQueue(tracking == null ? StringUtils.EMPTY : tracking.getTrackTo());
                     } else {
-                        // If there are no subtasks, sent to output queue
+                        // If there are no sub tasks, sent to output queue
                         return createSuccessResult(result);
                     }
                 default:

--- a/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
+++ b/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
@@ -90,13 +90,19 @@ public class BatchWorker extends AbstractWorker<BatchWorkerTask, BatchWorkerResu
                     // We return all results to the output queue
                     return createSuccessResult(result);
                 case RETURN_NONE:
-                    // If there are no errors then no output needs to be output
-                    return createSuccessNoOutputToQueue();
+                    //  If there are no errors then no output needs to be output.
+                    //  Also reset the 'trackTo' field on the tracking information but only if there are no
+                    //  subtasks.
+                    if (batchWorkerServices.hasSubtasks()) {
+                        return createSuccessNoOutputToQueue(false);
+                    } else {
+                        return createSuccessNoOutputToQueue(true);
+                    }
                 case RETURN_ONLY_IF_ZERO_SUBTASKS:
                     // We only return a result to the output queue if there were zero subfiles with the batch
                     if(batchWorkerServices.hasSubtasks()) {
                         // If there are subtasks, don't send to output queue
-                        return createSuccessNoOutputToQueue();
+                        return createSuccessNoOutputToQueue(false);
                     } else {
                         // If there are no subtasks, sent to output queue
                         return createSuccessResult(result);

--- a/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
+++ b/worker-batch/src/main/java/com/hpe/caf/worker/batch/BatchWorker.java
@@ -20,7 +20,6 @@ import com.hpe.caf.api.Codec;
 import com.hpe.caf.api.worker.*;
 import com.hpe.caf.worker.AbstractWorker;
 import com.rabbitmq.client.Connection;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -91,21 +90,18 @@ public class BatchWorker extends AbstractWorker<BatchWorkerTask, BatchWorkerResu
                     // We return all results to the output queue
                     return createSuccessResult(result);
                 case RETURN_NONE:
-                    //  If there are no errors then no output needs to be output.
-                    //  Also reset the 'trackTo' field on the tracking information but only if there are no
-                    //  subtasks.
+                    //  Return nothing to the output queue.
                     if (batchWorkerServices.hasSubtasks()) {
-                        return createSuccessNoOutputToQueue(tracking == null ? StringUtils.EMPTY : tracking.getTrackTo());
+                        return createSuccessNoOutputToQueue();
                     } else {
-                        return createSuccessNoOutputToQueue(null);
+                        //  Given no sub tasks, ensure the job is marked as completed.
+                        return createTaskCompleteResponse();
                     }
                 case RETURN_ONLY_IF_ZERO_SUBTASKS:
-                    // We only return a result to the output queue if there were zero subfiles with the batch
+                    // We only return a result to the output queue if there were zero sub files with the batch
                     if(batchWorkerServices.hasSubtasks()) {
-                        // If there are sub tasks, don't send to output queue
-                        return createSuccessNoOutputToQueue(tracking == null ? StringUtils.EMPTY : tracking.getTrackTo());
+                        return createSuccessNoOutputToQueue();
                     } else {
-                        // If there are no sub tasks, sent to output queue
                         return createSuccessResult(result);
                     }
                 default:


### PR DESCRIPTION
https://jira.autonomy.com/browse/CAF-2670

Changes to utilise the proposed worker-framework changes (see PR https://github.com/WorkerFramework/worker-framework/pull/60) to allow jobs with no sub-tasks to be completed.

Associated PRs for CAF-2670:
Worker-Framework: https://github.com/WorkerFramework/worker-framework/pull/60
Worker-GlobFilter: https://github.com/JobService/worker-globfilter/pull/4
Job-Service: https://github.com/JobService/job-service/pull/32