### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-batch-extensibility/pom.xml
+++ b/worker-batch-extensibility/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-batch-extensibility</artifactId>
+    <name>worker-batch-extensibility</name>
 
     <parent>
         <groupId>com.github.jobservice.workers.batch</groupId>

--- a/worker-batch-framework/pom.xml
+++ b/worker-batch-framework/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-batch-framework</artifactId>
+    <name>worker-batch-framework</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/worker-batch-shared/pom.xml
+++ b/worker-batch-shared/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-batch-shared</artifactId>
+    <name>worker-batch-shared</name>
 
     <parent>
         <groupId>com.github.jobservice.workers.batch</groupId>

--- a/worker-batch-testing/pom.xml
+++ b/worker-batch-testing/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-batch-testing</artifactId>
+    <name>worker-batch-testing</name>
 
     <dependencies>
         <dependency>

--- a/worker-batch/pom.xml
+++ b/worker-batch/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     
     <artifactId>worker-batch</artifactId>
+    <name>worker-batch</name>
 
     <parent>
         <groupId>com.github.jobservice.workers.batch</groupId>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210